### PR TITLE
Enable selection by ref

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
 
   checkout-ref:
-    description: 'Which branch of the repository to clone'
+    description: 'The branch, tag, or SHA of the repository to clone'
     required: false
 
   # java jdk params

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
     default: 'false'
     required: false
 
+  checkout-ref:
+    description: 'Which branch of the repository to clone'
+    required: false
 
   # java jdk params
 
@@ -80,6 +83,7 @@ runs:
         fetch-depth: '${{ inputs.checkout-fetch-depth }}'
         path: '${{ inputs.checkout-path }}'
         persist-credentials: '${{ inputs.checkout-persist-credentials }}'
+        ref: '${{ inputs.checkout-ref }}'
 
     - uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
A useful addition to this plugin that allows us to optionally specify a ref (branch, tag, or a SHA) to the [actions/checkout](https://github.com/actions/checkout) action.